### PR TITLE
ci: publish wheels to testpypi

### DIFF
--- a/.github/workflows/release-testpypi.yml
+++ b/.github/workflows/release-testpypi.yml
@@ -1,0 +1,38 @@
+---
+name: publish wheels to testpypi
+
+on:
+  push:
+    branches:
+      - main
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/python-gilt
+
+    permissions:
+      # mandatory for trusted publishing
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: git fetch --force --tags
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - uses: goreleaser/goreleaser-action@v5
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean --snapshot
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/release-testpypi.yml
+++ b/.github/workflows/release-testpypi.yml
@@ -1,12 +1,13 @@
 ---
 name: publish wheels to testpypi
 
-on:
-  push:
-    branches:
-      - main
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
+on: push
+  # TODO(retr0h): will enable prior to merge, testing action
+  # push:
+  #   branches:
+  #     - main
+  # # Allows you to run this workflow manually from the Actions tab
+  # workflow_dispatch:
 
 jobs:
   release:

--- a/.github/workflows/release-testpypi.yml
+++ b/.github/workflows/release-testpypi.yml
@@ -44,4 +44,4 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
-          packages-dir: dist/*.whl
+          packages-dir: dist/whl/

--- a/.github/workflows/release-testpypi.yml
+++ b/.github/workflows/release-testpypi.yml
@@ -44,3 +44,4 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+          packages-dir: dist/*.whl

--- a/.github/workflows/release-testpypi.yml
+++ b/.github/workflows/release-testpypi.yml
@@ -34,6 +34,13 @@ jobs:
           distribution: goreleaser
           version: latest
           args: release --clean --snapshot
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build Wheels
+        run: task build:wheel
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 ---
-name: goreleaser
+name: publish packages
 on:
   push:
     tags:
@@ -7,11 +7,9 @@ on:
 
 permissions:
   contents: write
-  # packages: write
-  # issues: write
 
 jobs:
-  goreleaser:
+  release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+__pycache__
 cobertura.xml
 cover.out
 dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,7 +17,7 @@ archives:
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ incpatch .Version }}.dev"
+  name_template: "{{ incpatch .PreviousTag }}-dev+{{ .ShortCommit }}"
 changelog:
   sort: asc
   filters:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,7 +17,7 @@ archives:
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ incpatch .Version }}.dev{{ .ShortCommit }}"
+  name_template: "{{ incpatch .Version }}.dev"
 changelog:
   sort: asc
   filters:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,7 +17,7 @@ archives:
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ incpatch .Version }}+dev.{{ .ShortCommit }}"
+  name_template: "{{ incpatch .Version }}.dev{{ .ShortCommit }}"
 changelog:
   sort: asc
   filters:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,7 +17,7 @@ archives:
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ incpatch .PreviousTag }}+dev.{{ .ShortCommit }}"
+  name_template: "{{ incpatch .Version }}+dev.{{ .ShortCommit }}"
 changelog:
   sort: asc
   filters:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,7 +17,7 @@ archives:
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ incpatch .Version }}.dev"
+  name_template: "{{ incpatch .Version }}.dev0"
 changelog:
   sort: asc
   filters:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,7 +17,7 @@ archives:
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ incpatch .PreviousTag }}-dev+{{ .ShortCommit }}"
+  name_template: "{{ incpatch .PreviousTag }}+dev.{{ .ShortCommit }}"
 changelog:
   sort: asc
   filters:

--- a/python/dist2wheel.py
+++ b/python/dist2wheel.py
@@ -56,7 +56,7 @@ class Wheels:
         with open("README.md") as f:
             self.readme = f.read()
 
-        self.distribution = self.metadata["project_name"]
+        self.distribution = f"python-{self.metadata['project_name']}"
         self.version = self.metadata["version"]
         self.py_tag = "py3"
         self.abi_tag = "none"

--- a/python/dist2wheel.py
+++ b/python/dist2wheel.py
@@ -113,7 +113,8 @@ class Wheels:
         return base64.urlsafe_b64encode(bytes.fromhex(checksum)).decode().rstrip("=")
 
     def _emit(self):
-        name_ver = f"{self.distribution}-{self.version}"
+        pypi_name = self.distribution.replace('-', '_')
+        name_ver = f"{pypi_name}-{self.version}"
         filename = os.path.join(self.wheel_dir, f"{name_ver}-{self.py_tag}-{self.abi_tag}-{self.platform_tag}.whl")
 
         with zipfile.ZipFile(filename, "w", compression=zipfile.ZIP_DEFLATED) as zf:

--- a/python/dist2wheel.py
+++ b/python/dist2wheel.py
@@ -21,7 +21,7 @@ import zipfile
 WHEEL_TEMPLATE = """Wheel-Version: 1.0
 Generator: dist2wheel.py
 Root-Is-Purelib: false
-Tag: {py_tag}-{abi_tag}-{platform_tag} 
+Tag: {py_tag}-{abi_tag}-{platform_tag}
 """
 METADATA_TEMPLATE = """Metadata-Version: 2.1
 Name: {distribution}
@@ -43,12 +43,14 @@ Description-Content-Type: text/markdown; charset=UTF-8; variant=GFM
 
 class Wheels:
     def __init__(self):
+        self.dist_dir = "dist"
+        self.wheel_dir = os.path.join(self.dist_dir, "whl")
         # Pull in all the project metadata from known locations.
         # No, this isn't customizable.  Cope.
-        with open("dist/metadata.json") as f:
+        with open(os.path.join(self.dist_dir, "metadata.json")) as f:
             self.metadata = json.load(f)
 
-        with open("dist/artifacts.json") as f:
+        with open(os.path.join(self.dist_dir, "artifacts.json")) as f:
             self.artifacts = json.load(f)
 
         with open("README.md") as f:
@@ -81,6 +83,7 @@ class Wheels:
 
             self.wheel_file = WHEEL_TEMPLATE.format(**self.__dict__).encode()
             self.metadata_file = METADATA_TEMPLATE.format(**self.__dict__).encode()
+            os.makedirs(self.wheel_dir, exist_ok=True)
             self._emit()
 
     @staticmethod
@@ -111,7 +114,8 @@ class Wheels:
 
     def _emit(self):
         name_ver = f"{self.distribution}-{self.version}"
-        filename = f"dist/{name_ver}-{self.py_tag}-{self.abi_tag}-{self.platform_tag}.whl"
+        filename = os.path.join(self.wheel_dir, f"{name_ver}-{self.py_tag}-{self.abi_tag}-{self.platform_tag}.whl")
+
         with zipfile.ZipFile(filename, "w", compression=zipfile.ZIP_DEFLATED) as zf:
             record = []
             print(f"writing {zf.filename}")

--- a/python/dist2wheel.py
+++ b/python/dist2wheel.py
@@ -76,6 +76,9 @@ class Wheels:
             try:
                 self.path = artifact["path"]
                 self.platform_tag = self._fixup_platform_tag(artifact)
+                # skipping for now: unsupported platform tag 'linux_aarch64
+                if self.platform_tag == "linux_aarch64":
+                    continue
                 self.checksum = self._fix_checksum(artifact["extra"]["Checksum"])
                 self.size = os.path.getsize(self.path)
             except KeyError:


### PR DESCRIPTION
Pushes binaries to testpypi on merge.

Fixes: #127