### PR TITLE
chore: build Universal binaries for OSX

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -65,3 +65,5 @@ brews:
       - name: go
         type: optional
       - name: git
+universal_binaries:
+  - replace: true

--- a/python/dist2wheel.py
+++ b/python/dist2wheel.py
@@ -89,18 +89,11 @@ class Wheels:
     def _matrix(self):
         return {
             "darwin": {
-                "amd64": {
-                    "arch": "x86_64",
-                    "platform": "macosx_10_15_x86_64",
+                "all": {
+                    "arch": "all",
+                    "platform": "macosx_10_15_universal2",
                     "tags": [
-                        f"{self.py_tag}-{self.abi_tag}-macosx_10_15_x86_64",
-                    ],
-                },
-                "arm64": {
-                    "arch": "arm64",
-                    "platform": "macosx_11_0_arm64",
-                    "tags": [
-                        f"{self.py_tag}-{self.abi_tag}-macosx_11_arm64",
+                        f"{self.py_tag}-{self.abi_tag}-macosx_10_15_universal2",
                     ],
                 },
             },


### PR DESCRIPTION
It's twice the size, but it makes distribution SO much simpler.