### PR TITLE
fix: fetch current tags from remote on clone cache hit

### DIFF
--- a/internal/git.go
+++ b/internal/git.go
@@ -24,4 +24,5 @@ package internal
 type GitManager interface {
 	Clone(gitURL string, cloneDir string) error
 	Worktree(cloneDir string, version string, dstDir string) error
+	Update(cloneDir string) error
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -57,6 +57,12 @@ func (g *Git) Clone(
 	)
 }
 
+// Update the repo.  Fetch the current HEAD and any new tags that may have
+// appeared, and update the cache.
+func (g *Git) Update(cloneDir string) error {
+	return g.execManager.RunCmdInDir("git", []string{"fetch", "--tags"}, cloneDir)
+}
+
 // Worktree create a working tree from the repo in `cloneDir` at `version` in `dstDir`.
 // Under the covers, this will download any/all required objects from origin
 // into the cache

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -86,6 +86,7 @@ func (g *Git) Worktree(
 	// this is just junk data in our use case, so get rid of it
 	if err == nil {
 		_ = os.Remove(filepath.Join(dst, ".git"))
+		_ = g.execManager.RunCmdInDir("git", []string{"worktree", "prune", "--verbose"}, cloneDir)
 	}
 	return err
 }

--- a/internal/git/git_public_test.go
+++ b/internal/git/git_public_test.go
@@ -108,6 +108,23 @@ func (suite *GitManagerPublicTestSuite) TestWorktreeError() {
 	assert.Error(suite.T(), err)
 }
 
+func (suite *GitManagerPublicTestSuite) TestUpdateOk() {
+	suite.mockExec.EXPECT().
+		RunCmdInDir("git", []string{"fetch", "--tags"}, suite.cloneDir).
+		Return(nil)
+	err := suite.gm.Update(suite.cloneDir)
+	assert.NoError(suite.T(), err)
+}
+
+func (suite *GitManagerPublicTestSuite) TestUpdateError() {
+	errors := errors.New("tests error")
+	suite.mockExec.EXPECT().
+		RunCmdInDir("git", []string{"fetch", "--tags"}, suite.cloneDir).
+		Return(errors)
+	err := suite.gm.Update(suite.cloneDir)
+	assert.Error(suite.T(), err)
+}
+
 // In order for `go test` to run this suite, we need to create
 // a normal test function and pass our suite to suite.Run.
 func TestGitManagerPublicTestSuite(t *testing.T) {

--- a/internal/git/git_public_test.go
+++ b/internal/git/git_public_test.go
@@ -92,6 +92,9 @@ func (suite *GitManagerPublicTestSuite) TestWorktreeOk() {
 	suite.mockExec.EXPECT().
 		RunCmdInDir("git", []string{"worktree", "add", "--force", suite.dstDir, suite.gitVersion}, suite.cloneDir).
 		Return(nil)
+	suite.mockExec.EXPECT().
+		RunCmdInDir("git", []string{"worktree", "prune", "--verbose"}, suite.cloneDir).
+		Return(nil)
 	err := suite.gm.Worktree(suite.cloneDir, suite.gitVersion, suite.dstDir)
 	assert.NoError(suite.T(), err)
 }

--- a/internal/mocks/git/git_mock.go
+++ b/internal/mocks/git/git_mock.go
@@ -47,6 +47,20 @@ func (mr *MockGitManagerMockRecorder) Clone(gitURL, cloneDir interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clone", reflect.TypeOf((*MockGitManager)(nil).Clone), gitURL, cloneDir)
 }
 
+// Update mocks base method.
+func (m *MockGitManager) Update(cloneDir string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Update", cloneDir)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Update indicates an expected call of Update.
+func (mr *MockGitManagerMockRecorder) Update(cloneDir interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockGitManager)(nil).Update), cloneDir)
+}
+
 // Worktree mocks base method.
 func (m *MockGitManager) Worktree(cloneDir, version, dstDir string) error {
 	m.ctrl.T.Helper()

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -100,6 +100,9 @@ func (r *Repository) Clone(
 		}
 	} else {
 		r.logger.Info("clone already exists", slog.String("dstDir", targetDir))
+		if err := r.gitManager.Update(targetDir); err != nil {
+			return targetDir, err
+		}
 	}
 
 	return targetDir, nil

--- a/internal/repository/repository_public_test.go
+++ b/internal/repository/repository_public_test.go
@@ -125,9 +125,27 @@ func (suite *RepositoryPublicTestSuite) TestCloneDoesNotCloneWhenCloneDirExists(
 	targetDir := filepath.Join(suite.cloneDir, suite.cacheDir)
 
 	_ = suite.appFs.MkdirAll(targetDir, 0o755)
+	suite.mockGit.EXPECT().Update(targetDir).Return(nil)
 
 	_, err := repo.Clone(c, suite.cloneDir)
 	assert.NoError(suite.T(), err)
+}
+
+func (suite *RepositoryPublicTestSuite) TestCloneUpdateCloneDirThrowsError() {
+	repo := suite.NewRepositoryManager()
+
+	c := config.Repository{
+		Git:     suite.gitURL,
+		Version: suite.gitSHA,
+	}
+	targetDir := filepath.Join(suite.cloneDir, suite.cacheDir)
+
+	_ = suite.appFs.MkdirAll(targetDir, 0o755)
+	errors := errors.New("tests error")
+	suite.mockGit.EXPECT().Update(targetDir).Return(errors)
+
+	_, err := repo.Clone(c, suite.cloneDir)
+	assert.Error(suite.T(), err)
 }
 
 func (suite *RepositoryPublicTestSuite) TestCopySourcesOkWhenSourceIsDirAndDstDirDoesNotExist() {


### PR DESCRIPTION
Special care and handling is needed to keep tags up-to-date with the remote; all other assets seem to be fetched/updated as needed.

Fixes: Issue #142