### PR TITLE
chore: add /v2 prefix in to `module` in `go.mod`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/retr0h/gilt
+module github.com/retr0h/gilt/v2
 
 go 1.21.0
 


### PR DESCRIPTION
Should fix https://github.com/golang/go/issues/65539 and #145