### PR TITLE
refactor: replace afero with avfs

### DIFF
--- a/examples/go-client/go.mod
+++ b/examples/go-client/go.mod
@@ -10,13 +10,13 @@ require (
 )
 
 require (
+	github.com/avfs/avfs v0.33.0 // indirect
 	github.com/danjacques/gofslock v0.0.0-20230728142113-ae8f59f9e88b // indirect
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.18.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
-	github.com/spf13/afero v1.11.0 // indirect
 	golang.org/x/crypto v0.19.0 // indirect
 	golang.org/x/net v0.21.0 // indirect
 	golang.org/x/sys v0.17.0 // indirect

--- a/examples/go-client/go.sum
+++ b/examples/go-client/go.sum
@@ -1,3 +1,5 @@
+github.com/avfs/avfs v0.33.0 h1:5WQXbUbr6VS7aani39ZN2Vrd/s3wLnyih1Sc4ExWTxs=
+github.com/avfs/avfs v0.33.0/go.mod h1:Q59flcFRYe9KYkNMfrLUJney3yeKGQpcWRyxsDBW7vI=
 github.com/danjacques/gofslock v0.0.0-20230728142113-ae8f59f9e88b h1:BBkZ6LZYtzMQ2Oo5LkovMmUp0gxAD+AnXzfknZlFTBo=
 github.com/danjacques/gofslock v0.0.0-20230728142113-ae8f59f9e88b/go.mod h1:9LABMmUSkKzt6FVQNEWdUTM0bz8Bt8MPyEcuZe0Sr8c=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -20,8 +22,6 @@ github.com/lmittmann/tint v1.0.4 h1:LeYihpJ9hyGvE0w+K2okPTGUdVLfng1+nDNVR4vWISc=
 github.com/lmittmann/tint v1.0.4/go.mod h1:HIS3gSy7qNwGCj+5oRjAutErFBl4BzdQP6cJZ0NfMwE=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/spf13/afero v1.11.0 h1:WJQKhtpdm3v2IzqG8VMqrr6Rf3UYpEF239Jy9wNepM8=
-github.com/spf13/afero v1.11.0/go.mod h1:GH9Y3pIexgf1MTIWtNGyogA5MwRIDXGUr+hbWNoBjkY=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 golang.org/x/crypto v0.19.0 h1:ENy+Az/9Y1vSrlrvBSyna3PITt4tiZLf7sgCjZBX7Wo=

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,11 @@ module github.com/retr0h/gilt/v2
 go 1.21.0
 
 require (
+	github.com/avfs/avfs v0.33.0
 	github.com/danjacques/gofslock v0.0.0-20230728142113-ae8f59f9e88b
 	github.com/go-playground/validator/v10 v10.18.0
 	github.com/golang/mock v1.6.0
 	github.com/lmittmann/tint v1.0.4
-	github.com/spf13/afero v1.11.0
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.8.4
@@ -32,6 +32,7 @@ require (
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
+	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAE
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
+github.com/avfs/avfs v0.33.0 h1:5WQXbUbr6VS7aani39ZN2Vrd/s3wLnyih1Sc4ExWTxs=
+github.com/avfs/avfs v0.33.0/go.mod h1:Q59flcFRYe9KYkNMfrLUJney3yeKGQpcWRyxsDBW7vI=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=

--- a/internal/exec/exec_public_test.go
+++ b/internal/exec/exec_public_test.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/avfs/avfs/vfs/memfs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
@@ -38,6 +39,7 @@ type ExecManagerPublicTestSuite struct {
 
 func (suite *ExecManagerPublicTestSuite) NewTestExecManager() internal.ExecManager {
 	return exec.New(
+		memfs.New(),
 		slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
 			Level: slog.LevelDebug,
 		})),

--- a/internal/exec/types.go
+++ b/internal/exec/types.go
@@ -22,9 +22,12 @@ package exec
 
 import (
 	"log/slog"
+
+	"github.com/avfs/avfs"
 )
 
 // Exec disk implementation.
 type Exec struct {
+	appFs  avfs.VFS
 	logger *slog.Logger
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -25,17 +25,15 @@ package git
 
 import (
 	"log/slog"
-	"os"
-	"path/filepath"
 
-	"github.com/spf13/afero"
+	"github.com/avfs/avfs"
 
 	"github.com/retr0h/gilt/v2/internal"
 )
 
 // New factory to create a new Git instance.
 func New(
-	appFs afero.Fs,
+	appFs avfs.VFS,
 	execManager internal.ExecManager,
 	logger *slog.Logger,
 ) *Git {
@@ -71,7 +69,7 @@ func (g *Git) Worktree(
 	version string,
 	dstDir string,
 ) error {
-	dst, err := filepath.Abs(dstDir)
+	dst, err := g.appFs.Abs(dstDir)
 	if err != nil {
 		return err
 	}
@@ -91,7 +89,7 @@ func (g *Git) Worktree(
 	// `git worktree add` creates a breadcrumb file back to the original repo;
 	// this is just junk data in our use case, so get rid of it
 	if err == nil {
-		_ = os.Remove(filepath.Join(dst, ".git"))
+		_ = g.appFs.Remove(g.appFs.Join(dst, ".git"))
 		_ = g.execManager.RunCmdInDir("git", []string{"worktree", "prune", "--verbose"}, cloneDir)
 	}
 	return err

--- a/internal/git/git_public_test.go
+++ b/internal/git/git_public_test.go
@@ -26,8 +26,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/avfs/avfs/vfs/memfs"
 	"github.com/golang/mock/gomock"
-	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
@@ -52,7 +52,7 @@ type GitManagerPublicTestSuite struct {
 
 func (suite *GitManagerPublicTestSuite) NewTestGitManager() internal.GitManager {
 	return git.New(
-		afero.NewMemMapFs(),
+		memfs.New(),
 		suite.mockExec,
 		slog.New(slog.NewTextHandler(os.Stdout, nil)),
 	)

--- a/internal/git/types.go
+++ b/internal/git/types.go
@@ -23,14 +23,14 @@ package git
 import (
 	"log/slog"
 
-	"github.com/spf13/afero"
+	"github.com/avfs/avfs"
 
 	"github.com/retr0h/gilt/v2/internal"
 )
 
 // Git implementation responsible for Git operations.
 type Git struct {
-	appFs       afero.Fs
+	appFs       avfs.VFS
 	execManager internal.ExecManager
 	logger      *slog.Logger
 }

--- a/internal/repositories/types.go
+++ b/internal/repositories/types.go
@@ -23,7 +23,7 @@ package repositories
 import (
 	"log/slog"
 
-	"github.com/spf13/afero"
+	"github.com/avfs/avfs"
 
 	"github.com/retr0h/gilt/v2/internal"
 	"github.com/retr0h/gilt/v2/pkg/config"
@@ -31,7 +31,7 @@ import (
 
 // Repositories perform repository operations.
 type Repositories struct {
-	appFs  afero.Fs
+	appFs  avfs.VFS
 	config config.Repositories
 	logger *slog.Logger
 

--- a/internal/repository/helper_test.go
+++ b/internal/repository/helper_test.go
@@ -21,11 +21,11 @@
 package repository_test
 
 import (
-	"github.com/spf13/afero"
+	"github.com/avfs/avfs"
 )
 
 type FileSpec struct {
-	appFs    afero.Fs
+	appFs    avfs.VFS
 	srcDir   string
 	srcFile  string
 	srcFiles []string

--- a/internal/repository/types.go
+++ b/internal/repository/types.go
@@ -23,14 +23,14 @@ package repository
 import (
 	"log/slog"
 
-	"github.com/spf13/afero"
+	"github.com/avfs/avfs"
 
 	"github.com/retr0h/gilt/v2/internal"
 )
 
 // Repository contains the repository's details for cloning.
 type Repository struct {
-	appFs       afero.Fs
+	appFs       avfs.VFS
 	copyManager CopyManager
 	gitManager  internal.GitManager
 	logger      *slog.Logger
@@ -44,6 +44,6 @@ type CopyManager interface {
 
 // Copy copy implementation.
 type Copy struct {
-	appFs  afero.Fs
+	appFs  avfs.VFS
 	logger *slog.Logger
 }

--- a/pkg/repositories/repositories.go
+++ b/pkg/repositories/repositories.go
@@ -24,11 +24,10 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"path/filepath"
 	"strconv"
 
+	"github.com/avfs/avfs/vfs/osfs"
 	"github.com/danjacques/gofslock/fslock"
-	"github.com/spf13/afero"
 
 	"github.com/retr0h/gilt/v2/internal/exec"
 	"github.com/retr0h/gilt/v2/internal/git"
@@ -43,7 +42,7 @@ func New(
 	c config.Repositories,
 	logger *slog.Logger,
 ) *Repositories {
-	appFs := afero.NewOsFs()
+	appFs := osfs.NewWithNoIdm()
 
 	copyManager := repository.NewCopy(
 		appFs,
@@ -51,6 +50,7 @@ func New(
 	)
 
 	execManager := exec.New(
+		appFs,
 		logger,
 	)
 
@@ -105,7 +105,7 @@ func (r *Repositories) withLock(fn func() error) error {
 		return err
 	}
 
-	lockFile := filepath.Join(lockDir, "gilt.lock")
+	lockFile := r.appFs.Join(lockDir, "gilt.lock")
 	r.logger.Info(
 		"acquiring lock",
 		slog.String("lockfile", lockFile),

--- a/pkg/repositories/types.go
+++ b/pkg/repositories/types.go
@@ -23,7 +23,7 @@ package repositories
 import (
 	"log/slog"
 
-	"github.com/spf13/afero"
+	"github.com/avfs/avfs"
 
 	"github.com/retr0h/gilt/v2/internal"
 	"github.com/retr0h/gilt/v2/pkg/config"
@@ -31,7 +31,7 @@ import (
 
 // Repositories perform repository operations.
 type Repositories struct {
-	appFs        afero.Fs
+	appFs        avfs.VFS
 	c            config.Repositories
 	reposManager internal.RepositoriesManager
 	logger       *slog.Logger


### PR DESCRIPTION
[avfs](https://github.com/avfs/avfs) does the same thing as afero, but provides a more complete abstraction layer, and a more fully-functional MemFS for testing, i.e., it supports symlinks.

Move all file operations over to avfs, including `exec.RunInTempDir`, and add unit tests for symlink handling.