### PR TITLE
test: Do a proper test teardown

### DIFF
--- a/internal/git/git_public_test.go
+++ b/internal/git/git_public_test.go
@@ -61,7 +61,6 @@ func (suite *GitManagerPublicTestSuite) NewTestGitManager() internal.GitManager 
 func (suite *GitManagerPublicTestSuite) SetupTest() {
 	suite.ctrl = gomock.NewController(suite.T())
 	suite.mockExec = exec.NewMockExecManager(suite.ctrl)
-	defer suite.ctrl.Finish()
 
 	suite.gitURL = "https://example.com/user/repo.git"
 	suite.gitVersion = "abc123"
@@ -69,6 +68,10 @@ func (suite *GitManagerPublicTestSuite) SetupTest() {
 	suite.dstDir = "/dstDir"
 
 	suite.gm = suite.NewTestGitManager()
+}
+
+func (suite *GitManagerPublicTestSuite) TearDownTest() {
+	defer suite.ctrl.Finish()
 }
 
 func (suite *GitManagerPublicTestSuite) TestCloneOk() {

--- a/internal/repositories/repositories_public_test.go
+++ b/internal/repositories/repositories_public_test.go
@@ -79,7 +79,6 @@ func (suite *RepositoriesPublicTestSuite) SetupTest() {
 	suite.ctrl = gomock.NewController(suite.T())
 	suite.mockRepo = repository.NewMockRepositoryManager(suite.ctrl)
 	suite.mockExec = exec.NewMockExecManager(suite.ctrl)
-	defer suite.ctrl.Finish()
 
 	suite.appFs = memfs.New()
 	suite.dstDir = "/dstDir"
@@ -95,6 +94,10 @@ func (suite *RepositoriesPublicTestSuite) SetupTest() {
 	}
 
 	suite.logger = slog.New(slog.NewTextHandler(os.Stdout, nil))
+}
+
+func (suite *RepositoriesPublicTestSuite) TearDownTest() {
+	defer suite.ctrl.Finish()
 }
 
 func (suite *RepositoriesPublicTestSuite) TestOverlayOkWhenDstDir() {
@@ -167,7 +170,6 @@ func (suite *RepositoriesPublicTestSuite) TestOverlayReturnsErrorWhenCloneErrors
 
 	errors := errors.New("tests error")
 	suite.mockRepo.EXPECT().Clone(gomock.Any(), gomock.Any()).Return("", errors)
-	suite.mockRepo.EXPECT().Worktree(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
 	err := repos.Overlay()
 	assert.Error(suite.T(), err)

--- a/internal/repositories/repositories_test.go
+++ b/internal/repositories/repositories_test.go
@@ -72,12 +72,15 @@ func (suite *RepositoriesTestSuite) SetupTest() {
 	suite.ctrl = gomock.NewController(suite.T())
 	suite.mockRepo = repository.NewMockRepositoryManager(suite.ctrl)
 	suite.mockExec = exec.NewMockExecManager(suite.ctrl)
-	defer suite.ctrl.Finish()
 
 	suite.appFs = memfs.New()
 	suite.giltDir = "/giltDir"
 
 	suite.logger = slog.New(slog.NewTextHandler(os.Stdout, nil))
+}
+
+func (suite *RepositoriesTestSuite) TearDownTest() {
+	defer suite.ctrl.Finish()
 }
 
 func (suite *RepositoriesTestSuite) TestgetCacheDir() {

--- a/internal/repository/repository_public_test.go
+++ b/internal/repository/repository_public_test.go
@@ -70,7 +70,6 @@ func (suite *RepositoryPublicTestSuite) SetupTest() {
 	suite.ctrl = gomock.NewController(suite.T())
 	suite.mockGit = git.NewMockGitManager(suite.ctrl)
 	suite.mockCopyManager = mock_repo.NewMockCopyManager(suite.ctrl)
-	defer suite.ctrl.Finish()
 
 	suite.appFs = memfs.New()
 	suite.cloneDir = "/cloneDir"
@@ -80,6 +79,10 @@ func (suite *RepositoryPublicTestSuite) SetupTest() {
 	suite.gitSHA = "abc123"
 	suite.gitTag = "v1.1"
 	suite.logger = slog.New(slog.NewTextHandler(os.Stdout, nil))
+}
+
+func (suite *RepositoryPublicTestSuite) TearDownTest() {
+	defer suite.ctrl.Finish()
 }
 
 func (suite *RepositoryPublicTestSuite) TestCloneOk() {


### PR DESCRIPTION
Call `gomock.Controller.Finish` at the end of `TearDownTest`, not `SetupTest`.  Clean up tests with useless mocks that never got called (which is now, rightly, an error)