### PR TITLE
refactor: use the File methods for Stat, Chmod

### DIFF
--- a/internal/mocks/vfs/failfs.go
+++ b/internal/mocks/vfs/failfs.go
@@ -383,6 +383,14 @@ func (f *FailFile) Chdir() error {
 }
 
 func (f *FailFile) Chmod(mode fs.FileMode) error {
+	if failFn, ok := f.vfs.failFn["file.Chmod"]; ok {
+		results := f.vfs.callFailFn(failFn, mode)
+		var err error
+		if !results[0].IsNil() {
+			err, _ = results[0].Interface().(error)
+		}
+		return err
+	}
 	return f.baseFile.Chmod(mode)
 }
 
@@ -433,6 +441,18 @@ func (f *FailFile) Seek(offset int64, whence int) (ret int64, err error) {
 }
 
 func (f *FailFile) Stat() (fs.FileInfo, error) {
+	if failFn, ok := f.vfs.failFn["file.Stat"]; ok {
+		results := f.vfs.callFailFn(failFn)
+		var fileInfo fs.FileInfo
+		var err error
+		if !results[0].IsNil() {
+			fileInfo, _ = results[0].Interface().(fs.FileInfo)
+		}
+		if !results[1].IsNil() {
+			err, _ = results[1].Interface().(error)
+		}
+		return fileInfo, err
+	}
 	return f.baseFile.Stat()
 }
 

--- a/internal/repository/copy.go
+++ b/internal/repository/copy.go
@@ -63,7 +63,7 @@ func (r *Copy) CopyFile(
 	}
 	defer func() { _ = in.Close() }()
 
-	si, err := r.appFs.Stat(src)
+	si, err := in.Stat()
 	if err != nil {
 		return err
 	}
@@ -76,7 +76,7 @@ func (r *Copy) CopyFile(
 	}
 	defer func() { _ = out.Close() }()
 
-	err = r.appFs.Chmod(dst, 0o600)
+	err = out.Chmod(0o600)
 	if err != nil {
 		return err
 	}
@@ -92,7 +92,7 @@ func (r *Copy) CopyFile(
 	}
 
 	// All done; make the permissions match
-	err = r.appFs.Chmod(dst, si.Mode())
+	err = out.Chmod(si.Mode())
 	if err != nil {
 		return err
 	}

--- a/internal/repository/copy_public_test.go
+++ b/internal/repository/copy_public_test.go
@@ -110,7 +110,7 @@ func (suite *CopyPublicTestSuite) TestCopyFileErrorStat() {
 	suite.appFs = failfs.New(
 		suite.appFs,
 		map[string]interface{}{
-			"Stat": func(string) (fs.FileInfo, error) { return nil, errors.New("FailFS!") },
+			"file.Stat": func() (fs.FileInfo, error) { return nil, errors.New("FailFS!") },
 		},
 	)
 	assertFile := suite.appFs.Join(suite.dstDir, "1.txt")
@@ -155,7 +155,7 @@ func (suite *CopyPublicTestSuite) TestCopyFileErrorSettingDestfilePerms() {
 	suite.appFs = failfs.New(
 		suite.appFs,
 		map[string]interface{}{
-			"Chmod": func(string, fs.FileMode) error { return errors.New("FailFS!") },
+			"file.Chmod": func(fs.FileMode) error { return errors.New("FailFS!") },
 		},
 	)
 	assertFile := suite.appFs.Join(suite.dstDir, "1.txt")
@@ -236,7 +236,7 @@ func (suite *CopyPublicTestSuite) TestCopyFileErrorFinalizingDestfilePerms() {
 	suite.appFs = failfs.New(
 		suite.appFs,
 		map[string]interface{}{
-			"Chmod": func(name string, mode fs.FileMode) error {
+			"file.Chmod": func(mode fs.FileMode) error {
 				if mode == 0o600 {
 					return nil
 				}


### PR DESCRIPTION
Use the already-open file descriptors for reading/writing metadata, rather than the long-form VFS versions.

Add/use FailFS fixtures as needed.