### PR TITLE
Switch to go 1.22

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
       - name: Install Task
         uses: arduino/setup-task@v2
         with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,8 +4,6 @@
 run:
   timeout: 5m
   modules-download-mode: readonly
-  skip-dirs:
-    - .asdf
 
 linters:
   enable:
@@ -28,3 +26,5 @@ issues:
   exclude-use-default: false
   max-issues-per-linter: 0
   max-same-issues: 0
+  exclude-dirs:
+    - .asdf

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -15,14 +15,14 @@ tasks:
   deps:
     desc: Install dependencies
     cmds:
-      - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.54.2
-      - go install github.com/princjef/gomarkdoc/cmd/gomarkdoc@v1.1.0
-      - go install golang.org/x/vuln/cmd/govulncheck@v1.0.1
-      - go install github.com/jstemmer/go-junit-report@v0.9.1
-      - go install github.com/segmentio/golines@v0.11.0
-      - go install github.com/golang/mock/mockgen@v1.6.0
-      - go install github.com/boumenot/gocover-cobertura@v1.2.0
-      - go install mvdan.cc/gofumpt@fd93f1d8818fc86a956b9706ad8b81734c81cc1e
+      - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin latest
+      - go install github.com/princjef/gomarkdoc/cmd/gomarkdoc@latest
+      - go install golang.org/x/vuln/cmd/govulncheck@latest
+      - go install github.com/jstemmer/go-junit-report@latest
+      - go install github.com/segmentio/golines@latest
+      - go install github.com/golang/mock/mockgen@latest
+      - go install github.com/boumenot/gocover-cobertura@latest
+      - go install mvdan.cc/gofumpt@latest
       - go install github.com/goreleaser/goreleaser@latest
 
   deps:check:
@@ -88,9 +88,12 @@ tasks:
 
   cov:
     desc: Generate coverage
+    env:
+      # https://github.com/golang/go/issues/65570
+      GOEXPERIMENT: nocoverageredesign
     cmds:
       - go test -race -coverprofile=cover.out -v $(go list ./... | grep -v /mocks) 2>&1 | go-junit-report --set-exit-code > result.xml || (cat result.xml && echo "fail" && exit 1)
-      - $(go env GOPATH)/bin/gocover-cobertura < cover.out > cobertura.xml
+      - gocover-cobertura < cover.out > cobertura.xml
       - go tool cover -func=cover.out
 
   cov:map:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -15,7 +15,7 @@ tasks:
   deps:
     desc: Install dependencies
     cmds:
-      - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin latest
+      - go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
       - go install github.com/princjef/gomarkdoc/cmd/gomarkdoc@latest
       - go install golang.org/x/vuln/cmd/govulncheck@latest
       - go install github.com/jstemmer/go-junit-report@latest

--- a/examples/go-client/go.mod
+++ b/examples/go-client/go.mod
@@ -1,6 +1,8 @@
 module example.com/client
 
-go 1.21.0
+go 1.22
+
+toolchain go1.22.2
 
 replace github.com/retr0h/gilt/v2 => ../../../gilt/
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/retr0h/gilt/v2
 
-go 1.21.0
+go 1.22
 
 require (
 	github.com/avfs/avfs v0.33.0


### PR DESCRIPTION
* Switched to go 1.22 and execute coverage with nocoverageredesign which seems to correct some buggy coverage reporting
* Also pinned deps to @latest from arbitrary versions
* Updated deprecated golangci config `run.skip-dirs`
* go mod tidy
* go install golangci-lint

Fixes: #179