### PR TITLE
ci: preserve dependabot branches

### DIFF
--- a/.github/delete-merged-branch-config.yml
+++ b/.github/delete-merged-branch-config.yml
@@ -1,0 +1,5 @@
+---
+exclude:
+  # dependabot auto deletes it's own branches
+  - dependabot/*
+delete_closed_pr: true


### PR DESCRIPTION
Allow dependabot to delete it's own branches.