### PR TITLE
fix: allow dist2wheel to handle missing field

### DIFF
--- a/python/dist2wheel.py
+++ b/python/dist2wheel.py
@@ -66,7 +66,7 @@ class Wheels:
 
         # Burn a pass through the list to steal some useful bits from the Brew config
         for artifact in self.artifacts:
-            if "BrewConfig" in artifact["extra"]:
+            if artifact["type"] == "Brew Tap":
                 self.description = artifact["extra"]["BrewConfig"]["description"]
                 self.license = artifact["extra"]["BrewConfig"]["license"]
 


### PR DESCRIPTION
Allow `dist2wheel.py` to better handle missing extra field on the internal goreleaser build artifact.

Fixes: #193