### PR TITLE
fix: create/move refs for main

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -58,7 +58,11 @@ func (g *Git) Clone(
 // Update the repo.  Fetch the current HEAD and any new tags that may have
 // appeared, and update the cache.
 func (g *Git) Update(cloneDir string) error {
-	return g.execManager.RunCmdInDir("git", []string{"fetch", "--tags", "--force"}, cloneDir)
+	return g.execManager.RunCmdInDir(
+		"git",
+		[]string{"fetch", "--tags", "--force", "origin", "+refs/heads/*:refs/heads/*"},
+		cloneDir,
+	)
 }
 
 // Worktree create a working tree from the repo in `cloneDir` at `version` in `dstDir`.

--- a/internal/git/git_public_test.go
+++ b/internal/git/git_public_test.go
@@ -132,7 +132,7 @@ func (suite *GitManagerPublicTestSuite) TestWorktreeErrorWhenAbsErrors() {
 
 func (suite *GitManagerPublicTestSuite) TestUpdateOk() {
 	suite.mockExec.EXPECT().
-		RunCmdInDir("git", []string{"fetch", "--tags", "--force"}, suite.cloneDir).
+		RunCmdInDir("git", []string{"fetch", "--tags", "--force", "origin", "+refs/heads/*:refs/heads/*"}, suite.cloneDir).
 		Return(nil)
 	err := suite.gm.Update(suite.cloneDir)
 	assert.NoError(suite.T(), err)
@@ -141,7 +141,7 @@ func (suite *GitManagerPublicTestSuite) TestUpdateOk() {
 func (suite *GitManagerPublicTestSuite) TestUpdateError() {
 	errors := errors.New("tests error")
 	suite.mockExec.EXPECT().
-		RunCmdInDir("git", []string{"fetch", "--tags", "--force"}, suite.cloneDir).
+		RunCmdInDir("git", []string{"fetch", "--tags", "--force", "origin", "+refs/heads/*:refs/heads/*"}, suite.cloneDir).
 		Return(errors)
 	err := suite.gm.Update(suite.cloneDir)
 	assert.Error(suite.T(), err)


### PR DESCRIPTION
Corrects the issue where Gilt does not overlay when the target repo has been updated.

Fixes: #190