### PR TITLE
fix: wait for the lockfile on startup

### DIFF
--- a/test/integration/test_cli.bats
+++ b/test/integration/test_cli.bats
@@ -230,3 +230,8 @@ teardown() {
 	run stat /tmp/initGiltfile.yaml
 	[ "$status" = 0 ]
 }
+
+@test "concurrent gilt overlay will block/wait" {
+	run bash -c "cd ${GILT_TEST_BASE_TMP_DIR}; (for x in {1..8}; do go run ${GILT_PROGRAM} overlay & done ; wait) 2>&1 | grep ERR"
+	[ "$status" -eq 1 ]
+}


### PR DESCRIPTION
Block on acquiring the global lock, rather than aborting.

Fixes: Issue #202