### PR TITLE
fix: quit claiming Linux is an unsupported dev environment

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -30,7 +30,7 @@ tasks:
     cmds:
       - echo "Dependency check OK"
     preconditions:
-      - sh: "[ '{{OS}}' = 'darwin' ]"
+      - sh: "case '{{OS}}' in darwin|linux) true ;; *) false ;; esac"
         msg: Operating System '{{OS}}' not supported
 
       - sh: command -v jq


### PR DESCRIPTION
At least in the case of Debian Bookworm, the Go 1.22.3 runtime on Linux builds Gilt just fine.  It can even cross-compile working Universal binaries for Darwin.

Quit drinking the haterade and lying when asked if it's a supported environment.