### PR TITLE
fix: make CopyFile create target directories with sensible permissions

### DIFF
--- a/internal/repository/copy.go
+++ b/internal/repository/copy.go
@@ -68,9 +68,13 @@ func (r *Copy) CopyFile(
 		return err
 	}
 
+	// Ensure target directory exists; it will be created with the same mode as
+	// the target file, plus x-bits.
+	dirMode := si.Mode() & 0o777
+	dirMode |= ((dirMode & 0o444) >> 2) | ((dirMode & 0o222) >> 1)
+	_ = r.appFs.MkdirAll(r.appFs.Dir(dst), dirMode)
 	// Open dest file for writing; make it owner-only perms before putting
 	// anything in it
-	_ = r.appFs.MkdirAll(r.appFs.Dir(dst), si.Mode())
 	out, err := r.appFs.Create(dst)
 	if err != nil {
 		return err

--- a/internal/repository/copy_public_test.go
+++ b/internal/repository/copy_public_test.go
@@ -76,6 +76,10 @@ func (suite *CopyPublicTestSuite) TestCopyFileOk() {
 
 	got, _ := avfs.Exists(suite.appFs, assertFile)
 	assert.True(suite.T(), got)
+	// ensure target dir is created with sensible permissions — expressed
+	// in "canonical" form here so the test result is legible
+	parent, _ := suite.appFs.Stat(suite.dstDir)
+	assert.Equal(suite.T(), fs.FileMode(0o20000000755), parent.Mode())
 }
 
 func (suite *CopyPublicTestSuite) TestCopyFileReturnsError() {


### PR DESCRIPTION
Traversal bits (aka, x-bits) on directories are occasionally useful. Make sure they are set when creating target dirs.

Fixes: Issue #214