### PR TITLE
fix: disallow `.` and `..` for `dstDir`

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -112,8 +112,10 @@ commit hash may be used.
 
 The local directory to copy files into. All files in the repository will be
 copied. Relative paths will be installed into the directory where `gilt` was
-invoked. To copy only a subset of files, use the `repositories.sources` option
-instead.
+invoked. If `dstDir` already exists, it will be destroyed and overwritten; as
+such, `.` and `..` are not allowed.
+
+To copy only a subset of files, use the `repositories.sources` option instead.
 
 This option cannot be used with `repositories.sources`.
 
@@ -145,7 +147,8 @@ The pathname of the source file/directory to copy.
 The pathname of the destination directory. If `src` is a file, it will be placed
 inside the named directory. If `src` is a directory, its contents will be copied
 into the named directory. All parent directories will be created if they do not
-exist.
+exist. If `dstDir` already exists, it will be destroyed and overwritten; as
+such, `.` and `..` are not allowed.
 
 This option cannot be used with `repositories[].sources[].dstFile`.
 

--- a/pkg/config/schema_test.go
+++ b/pkg/config/schema_test.go
@@ -119,6 +119,14 @@ func (suite *SchemaTestSuite) TestSourceSchema() {
 			DstFile: "dstFile",
 			DstDir:  "dstDir",
 		}, "Key: 'Source.DstFile' Error:Field validation for 'DstFile' failed on the 'excluded_with' tag\nKey: 'Source.DstDir' Error:Field validation for 'DstDir' failed on the 'excluded_with' tag"},
+		{&Source{
+			Src:    "src",
+			DstDir: ".",
+		}, "Key: 'Source.DstDir' Error:Field validation for 'DstDir' failed on the 'ne' tag"},
+		{&Source{
+			Src:    "src",
+			DstDir: "..",
+		}, "Key: 'Source.DstDir' Error:Field validation for 'DstDir' failed on the 'ne' tag"},
 	}
 
 	for _, test := range tests {
@@ -203,6 +211,16 @@ func (suite *SchemaTestSuite) TestRepositorySchema() {
 				},
 			},
 		}, "Key: 'Repository.DstDir' Error:Field validation for 'DstDir' failed on the 'excluded_with' tag\nKey: 'Repository.Sources[0]' Error:Field validation for 'Sources[0]' failed on the 'excluded_with' tag"},
+		{&Repository{
+			Git:     "gitURL",
+			Version: "abc1234",
+			DstDir:  ".",
+		}, "Key: 'Repository.DstDir' Error:Field validation for 'DstDir' failed on the 'ne' tag"},
+		{&Repository{
+			Git:     "gitURL",
+			Version: "abc1234",
+			DstDir:  "..",
+		}, "Key: 'Repository.DstDir' Error:Field validation for 'DstDir' failed on the 'ne' tag"},
 	}
 
 	for _, test := range tests {

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -43,7 +43,7 @@ type Source struct {
 	// DstFile destination of file copy.
 	DstFile string `mapstructure:"dstFile" validate:"required_without=DstDir,excluded_with=DstDir"`
 	// DstDir destination of directory copy.
-	DstDir string `mapstructure:"dstDir"  validate:"required_without=DstFile,excluded_with=DstFile"`
+	DstDir string `mapstructure:"dstDir"  validate:"required_without=DstFile,excluded_with=DstFile,ne=.,ne=.."`
 }
 
 //  Water string `validate:"required_without=Fire,excluded_with=Fire"`
@@ -61,7 +61,7 @@ type Repository struct {
 	// Version the commit SHA or tag to use.
 	Version string `mapstructure:"version"  validate:"required"`
 	// DstDir destination directory to copy clone to.
-	DstDir string `mapstructure:"dstDir"   validate:"required_without=Sources,excluded_with=Sources"`
+	DstDir string `mapstructure:"dstDir"   validate:"required_without=Sources,excluded_with=Sources,ne=.,ne=.."`
 	// Sources containing files and/or directories to copy.
 	Sources []Source `mapstructure:"sources"  validate:"dive,required_without=DstDir,excluded_with=DstDir"`
 	// Commands commands to execute on Repository.


### PR DESCRIPTION
The overlay code calls `RemoveAll` on existing target directories, which absolutely does not work when the target directory is the current or parent directory.  Check for this when validating the config file, so it can fail-fast.

Update docs to explicitly admonish people trying to do this.

Fixes: Issue #228