### PR TITLE
ci: no reason to use go-junit-report

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -94,7 +94,7 @@ tasks:
       # https://github.com/golang/go/issues/65570
       GOEXPERIMENT: nocoverageredesign
     cmds:
-      - go test -race -coverprofile=cover.out -v $(go list ./... | grep -v /mocks) 2>&1 | go-junit-report --set-exit-code > result.xml || (cat result.xml && echo "fail" && exit 1)
+      - go test -race -coverprofile=cover.out -v $(go list ./... | grep -v /mocks)
       - gocover-cobertura < cover.out > cobertura.xml
       - go tool cover -func=cover.out
 


### PR DESCRIPTION
Not entirely sure why I had setup go-junit-report as gocover-cobertura does what we want.