### PR TITLE
fix: pin go toolchain to 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,9 @@
 module github.com/retr0h/gilt/v2
 
-go 1.23
+go 1.23.0
+
+toolchain go1.23.3
+
 require (
 	github.com/avfs/avfs v0.35.0
 	github.com/caarlos0/go-version v0.2.0


### PR DESCRIPTION
Will upgrade to go 1.24 at a later date.

* actions/setup-go@v5 installs Go 1.23
* one of the dependencies declares go 1.24 or higher
* starting in Go 1.21, the go command can auto-download a newer Go version if needed to match the declared version
* when a build runs, Go detects the mismatch and downloads & switches to Go 1.24.1
* this causes golangci-lint (built with Go 1.23) to fail