### PR TITLE
chore: exempt pinned issues from the stale bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,3 +16,5 @@ jobs:
         stale-pr-message: 'Stale pull request message'
         stale-issue-label: 'no-issue-activity'
         stale-pr-label: 'no-pr-activity'
+        exempt-issue-labels: 'pinned'
+        exempt-pr-labels: 'pinned'


### PR DESCRIPTION
## Summary

`actions/stale` ran with no exemption list, so long-running tracking issues blocked on upstream work were auto-closed after 60 days of inactivity (default `days-before-stale: 60`, `days-before-close: 7`).

Worse, the action only processes **open** issues and PRs. Once it closes something, later comments can never revive it — the `no-issue-activity` label just sits there permanently. #72 hit exactly this: closed as `NOT_PLANNED` on 2026-04-25 despite active interest, and subsequent comments had no effect.

## Change

Issues and PRs labeled `pinned` are now skipped entirely by the stale bot:

```yaml
exempt-issue-labels: 'pinned'
exempt-pr-labels: 'pinned'
```

## Also done outside this PR

- Created the `pinned` label on this repo.
- Reopened #72, removed `no-issue-activity`, applied `pinned`.

Ref #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)