### PR TITLE
refactor: guard `gilt init` against TOCTOU attacks

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -67,18 +67,18 @@ current working directory.`,
 		}
 
 		configFile := viper.GetString("giltFile")
-		_, err := os.Stat(configFile)
-		if err == nil {
+		configFileHandle, err := os.OpenFile(configFile, os.O_CREATE|os.O_WRONLY|os.O_EXCL, 0o644)
+		if err != nil {
 			logFatal(
-				"file already exists",
+				"could not create file",
 				slog.Group(
 					"",
 					slog.String("Giltfile", configFile),
+					slog.String("err", err.Error()),
 				),
 			)
 		}
-
-		if err := os.WriteFile(configFile, b.Bytes(), 0o644); err != nil {
+		if _, err = configFileHandle.Write(b.Bytes()); err != nil {
 			logFatal(
 				"failed to write file",
 				slog.Group(
@@ -88,7 +88,7 @@ current working directory.`,
 				),
 			)
 		}
-
+		_ = configFileHandle.Close()
 		fmt.Printf("wrote %s\n", configFile)
 	},
 }

--- a/test/integration/test_cli.bats
+++ b/test/integration/test_cli.bats
@@ -226,9 +226,15 @@ teardown() {
 
 @test "invoke gilt init" {
 	run bash -c "cd ${GILT_TEST_BASE_TMP_DIR}; go run ${GILT_PROGRAM} init -f /tmp/initGiltfile.yaml"
+	[ "$status" = 0 ]
 
 	run stat /tmp/initGiltfile.yaml
 	[ "$status" = 0 ]
+}
+
+@test "invoke gilt init failure" {
+	run bash -c "cd ${GILT_TEST_BASE_TMP_DIR}; touch /tmp/initGiltfile.yaml; go run ${GILT_PROGRAM} init -f /tmp/initGiltfile.yaml"
+	[ "$status" = 1 ]
 }
 
 @test "concurrent gilt overlay will block/wait" {


### PR DESCRIPTION
Attempt to open the target file with `O_CREAT|O_EXCL` rather than switching off the results of `os.Stat()`; this makes it impossible for attackers to sneak in a target file between the `os.Stat()` and the `os.WriteFile()` invocations.

Adds an integration test for `gilt init` failures

Not a huge security concern, considering what `gilt init` does, but a security concern nonetheless.